### PR TITLE
feat: Create static portal showcase with login

### DIFF
--- a/docs-site/src/pages/index.tsx
+++ b/docs-site/src/pages/index.tsx
@@ -1,31 +1,6 @@
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
-import Layout from '@theme/Layout';
-import type { ReactNode } from 'react';
-import AdvantageCards from '../components/AdvantageCards';
-import LandingHero from '../components/LandingHero';
-import LicenseFooter from '../components/LicenseFooter';
-import ResilienceSection from '../components/ResilienceSection';
-import InfoCardsRow from '../components/InfoCardsRow';
-import AwsStack from '../components/AwsStack';
-import IconCarousel from '../components/IconCarousel';
+import React from 'react';
+import {Redirect} from '@docusaurus/router';
 
-export default function Home(): ReactNode {
-  const { siteConfig } = useDocusaurusContext();
-  return (
-    <Layout
-      title={`${siteConfig.title}`}
-      description="Secure your future with Shieldcraft AI">
-      <main>
-        <div>
-          <LandingHero />
-          <AdvantageCards />
-          <InfoCardsRow />
-          <AwsStack />
-          <ResilienceSection />
-          <IconCarousel />
-          <LicenseFooter />
-        </div>
-      </main>
-    </Layout>
-  );
+export default function Home(): JSX.Element {
+  return <Redirect to="/login" />;
 }

--- a/docs-site/src/pages/login.module.css
+++ b/docs-site/src/pages/login.module.css
@@ -1,0 +1,20 @@
+.loginContainer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 80vh;
+}
+
+.loginBox {
+  background-color: var(--ifm-card-background-color);
+  padding: 40px;
+  border-radius: 10px;
+  text-align: center;
+  max-width: 400px;
+  width: 100%;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+}
+
+.loginBox h1 {
+  color: var(--ifm-color-primary);
+}

--- a/docs-site/src/pages/login.tsx
+++ b/docs-site/src/pages/login.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import Layout from '@theme/Layout';
+import Link from '@docusaurus/Link';
+import styles from './login.module.css';
+
+function LoginPage() {
+  return (
+    <Layout title="Login" description="Login to ShieldCraft AI">
+      <div className={styles.loginContainer}>
+        <div className={styles.loginBox}>
+          <h1>ShieldCraft AI</h1>
+          <p>Next-Gen Cloud Cybersecurity</p>
+          <Link className="button button--primary button--lg" to="/portal">
+            Login with SSO
+          </Link>
+        </div>
+      </div>
+    </Layout>
+  );
+}
+
+export default LoginPage;

--- a/docs-site/src/pages/portal.module.css
+++ b/docs-site/src/pages/portal.module.css
@@ -1,0 +1,117 @@
+:root {
+    --portal-primary-color: #25c2a0;
+    --portal-background-color: #1a1a1a;
+    --portal-sidebar-bg: #1f1f1f;
+    --portal-widget-bg: #2a2a2a;
+    --portal-text-color: #e0e0e0;
+    --portal-header-bg: #222222;
+    --portal-border-color: #333;
+}
+
+.container {
+    display: flex;
+    background-color: var(--portal-background-color);
+    color: var(--portal-text-color);
+    min-height: 100vh;
+}
+
+.sidebar {
+    width: 250px;
+    background-color: var(--portal-sidebar-bg);
+    height: 100vh;
+    padding: 20px;
+    box-sizing: border-box;
+    position: fixed;
+    top: 0;
+    left: 0;
+}
+
+.logo a {
+    color: var(--portal-primary-color);
+    font-size: 24px;
+    font-weight: bold;
+    text-decoration: none;
+}
+
+.navigation ul {
+    list-style: none;
+    padding: 0;
+    margin-top: 40px;
+}
+
+.navigation ul li {
+    margin-bottom: 15px;
+    cursor: pointer;
+}
+
+.navigation ul li a {
+    color: var(--portal-text-color);
+    text-decoration: none;
+    font-size: 16px;
+    display: block;
+    padding: 10px;
+    border-radius: 5px;
+}
+
+.navigation ul li.active a,
+.navigation ul li a:hover {
+    background-color: var(--portal-widget-bg);
+    color: var(--portal-primary-color);
+}
+
+.mainContent {
+    flex-grow: 1;
+    padding: 20px;
+    margin-left: 250px; /* Same as sidebar width */
+}
+
+.header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background-color: var(--portal-header-bg);
+    padding: 10px 20px;
+    border-radius: 5px;
+    margin-bottom: 20px;
+}
+
+.searchBar input {
+    background: var(--portal-widget-bg);
+    border: 1px solid var(--portal-border-color);
+    border-radius: 5px;
+    color: var(--portal-text-color);
+    padding: 8px 12px;
+    width: 300px;
+}
+
+.userInfo {
+    display: flex;
+    align-items: center;
+}
+
+.userInfo span {
+    margin-right: 20px;
+}
+
+.dashboard {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 20px;
+}
+
+.widget {
+    background-color: var(--portal-widget-bg);
+    padding: 20px;
+    border-radius: 5px;
+    border: 1px solid var(--portal-border-color);
+    transition: transform 0.2s ease-in-out;
+}
+
+.widget:hover {
+    transform: translateY(-5px);
+}
+
+.widget h3 {
+    margin-top: 0;
+    color: var(--portal-primary-color);
+}

--- a/docs-site/src/pages/portal.tsx
+++ b/docs-site/src/pages/portal.tsx
@@ -1,0 +1,75 @@
+import React, { useState, useEffect } from 'react';
+import Layout from '@theme/Layout';
+import Link from '@docusaurus/Link';
+import { useLocation } from '@docusaurus/router';
+import styles from './portal.module.css';
+import clsx from 'clsx';
+
+function PortalPage() {
+    const [activeLink, setActiveLink] = useState('Dashboard');
+    const navItems = ['Dashboard', 'Alerts', 'Attack Simulations', 'Threat Intelligence', 'Remediation', 'Analytics', 'Settings'];
+    const location = useLocation();
+
+    useEffect(() => {
+        const hash = location.hash.replace('#', '');
+        const currentItem = navItems.find(item => item.toLowerCase().replace(/ /g, '-') === hash);
+        if (currentItem) {
+            setActiveLink(currentItem);
+        } else {
+            setActiveLink('Dashboard');
+        }
+    }, [location.hash]);
+
+
+    return (
+        <Layout title="Portal" description="ShieldCraft AI Portal" noFooter>
+            <div className={styles.container}>
+                <aside className={styles.sidebar}>
+                    <div className={styles.logo}>
+                        <Link to="/portal">ShieldCraft AI</Link>
+                    </div>
+                    <nav className={styles.navigation}>
+                        <ul>
+                            {navItems.map(item => (
+                                <li key={item} className={clsx({[styles.active]: activeLink === item})} onClick={() => setActiveLink(item)}>
+                                    <Link to={`/portal#${item.toLowerCase().replace(/ /g, '-')}`}>{item}</Link>
+                                </li>
+                            ))}
+                        </ul>
+                    </nav>
+                </aside>
+                <main className={styles.mainContent}>
+                    <header className={styles.header}>
+                        <div className={styles.searchBar}>
+                            <input type="text" placeholder="Search..." />
+                        </div>
+                        <div className={styles.userInfo}>
+                            <span>Welcome, Analyst</span>
+                            <Link className={clsx('button', 'button--secondary')} to="/login">Logout</Link>
+                        </div>
+                    </header>
+                    <section className={styles.dashboard}>
+                        <div className={styles.widget}>
+                            <h3>Active Alerts</h3>
+                            <p>Placeholder for active alerts widget.</p>
+                        </div>
+                        <div className={styles.widget}>
+                            <h3>System Status</h3>
+                            <p>Placeholder for system status widget.</p>
+                        </div>
+                        <div className={styles.widget}>
+                            <h3>Recent Activity</h3>
+                            <p>Placeholder for recent activity widget.</p>
+                        </div>
+                        <div className={styles.widget}>
+                            <h3>Threat Feed</h3>
+                            <p>Placeholder for threat feed widget.</p>
+                        </div>
+                    </section>
+                </main>
+            </div>
+        </Layout>
+    );
+}
+
+export default PortalPage;


### PR DESCRIPTION
Adds a new static website within the Docusaurus application to serve as a showcase for the ShieldCraft AI back-office portal.

This includes:
- A mock login page at `/login` that simulates an SSO login flow.
- A portal dashboard page at `/portal` with a sidebar, header, and placeholder widgets.
- The site's entry point at `/` now redirects to `/login`.
- Navigation in the portal sidebar and the logout button are functional within the context of the showcase.